### PR TITLE
Conda recipes with linked ipopt

### DIFF
--- a/conda_recipes/PySCIPOpt/meta.yaml
+++ b/conda_recipes/PySCIPOpt/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: master
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/conda_recipes/ipoptlib/build.sh
+++ b/conda_recipes/ipoptlib/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# TODO: get any 3rd party code?
+# get some 3rd party code
+cd ThirdParty/Metis && ./get.Metis && cd ../../
+cd ThirdParty/Mumps && ./get.Mumps && cd ../../
 
-./configure --prefix=${PREFIX}
-# BLAS from mkl?
-# LAPACK from mkl?
-# HSL?
-# other libraries?
+./configure --prefix=${PREFIX} \
+            --with-blas="-L${PREFIX} -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl" \
+            --with-lapack="-L${PREFIX} -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl"
+# no HSL!
 
 make
 make install
-

--- a/conda_recipes/ipoptlib/build.sh
+++ b/conda_recipes/ipoptlib/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# TODO: get any 3rd party code?
+
+./configure --prefix=${PREFIX}
+# BLAS from mkl?
+# LAPACK from mkl?
+# HSL?
+# other libraries?
+
+make
+make install
+

--- a/conda_recipes/ipoptlib/build.sh
+++ b/conda_recipes/ipoptlib/build.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # get some 3rd party code
-cd ThirdParty/Metis && ./get.Metis && cd ../../
-cd ThirdParty/Mumps && ./get.Mumps && cd ../../
+THIRDPARTY=(Blas Lapack Metis Mumps)
+for TP in ${THIRDPARTY[@]}
+do
+    cd ThirdParty/${TP} && ./get.${TP} && cd ../../
+done
 
-./configure --prefix=${PREFIX} \
-            --with-blas="-L${PREFIX} -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl" \
-            --with-lapack="-L${PREFIX} -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lpthread -lm -ldl"
+./configure --prefix=${PREFIX}
 # no HSL!
 
 make

--- a/conda_recipes/ipoptlib/meta.yaml
+++ b/conda_recipes/ipoptlib/meta.yaml
@@ -14,9 +14,6 @@ build:
 requirements:
   build:
     - gcc # includes fortran
-    - mkl # for BLAS, Lapack
-  run:
-    - mkl
   
 about:
   home: https://projects.coin-or.org/Ipopt

--- a/conda_recipes/ipoptlib/meta.yaml
+++ b/conda_recipes/ipoptlib/meta.yaml
@@ -13,7 +13,8 @@ build:
 
 requirements:
   build:
-    - mkl
+    - gcc # includes fortran
+    - mkl # for BLAS, Lapack
   run:
     - mkl
   

--- a/conda_recipes/ipoptlib/meta.yaml
+++ b/conda_recipes/ipoptlib/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: ipoptlib
+  version: "3.12.5"
+
+source:
+  fn: Ipopt-3.12.5.tgz
+  url: http://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.5.tgz
+  md5: be47968fde7761ab609009450247f895
+  sha1: 3f63ddfff517235ead17af6cceb426ca858dda37
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - mkl
+  run:
+    - mkl
+  
+about:
+  home: https://projects.coin-or.org/Ipopt
+  license: Eclipse Public License (EPL)
+  summary: 'Software package for large-scale nonlinear optimization'

--- a/conda_recipes/scipoptlib/build.sh
+++ b/conda_recipes/scipoptlib/build.sh
@@ -1,8 +1,20 @@
+#!/bin/bash
+
 VERSION=3.2.1
+OSTYPE=linux
+ARCH=x86_64
+COMP=gnu
+IPOPTOPT=opt
+
 SCIPDIR=scip-$VERSION
 
+# manually create symlinks to IPOPT "installation directory"
+tar xf ${SCIPDIR}.tgz
+mkdir -p ${SCIPDIR}/lib
+ln -s ${PREFIX} ${SCIPDIR}/lib/ipopt.${OSTYPE}.${ARCH}.${COMP}.${IPOPTOPT}
+
 # build the shared library only
-make scipoptlib SHARED=true GMP=false READLINE=false
+make scipoptlib SHARED=true IPOPT=true GMP=false READLINE=false
 
 # "install" the shared library
 cp lib/libscipopt-*.so ${PREFIX}/lib/libscipopt.so

--- a/conda_recipes/scipoptlib/meta.yaml
+++ b/conda_recipes/scipoptlib/meta.yaml
@@ -9,13 +9,16 @@ source:
   md5: c8e4d39a447ef651e3d49a3955c24450
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
+    - gcc
     - zlib
+    - ipoptlib
   run:
     - zlib
+    - ipoptlib
 
 about:
   home: http://scip.zib.de

--- a/conda_setup.py
+++ b/conda_setup.py
@@ -9,7 +9,7 @@ extensions = [Extension('pyscipopt.scip', ['pyscipopt/scip.pyx'],
                         extra_compile_args=['-UNDEBUG'],
                         include_dirs=['lib/scip-src'],
                         library_dirs=['lib'],
-                        libraries=['m', 'scipopt', 'z'])]
+                        libraries=['m', 'scipopt', 'z', 'ipopt'])]
 
 setup(
     name = 'pyscipopt',


### PR DESCRIPTION
I got everything working, more or less.

Instead of reusing some BLAS and Lapack from a conda package, I now compile everything with IPOPT.

Also, `ipoptlib` is now *required* for both `scipoptlib` and (implicitely) `pyscipopt`.

The `make scipoptlib` now requires a user to press [Enter] once :sob:, but I guess that's acceptable, since the end users will use precompiled packages anyway.