### PR TITLE
only link to scipoptlib

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,9 +6,9 @@ Therefore you have to run
 
     make SHARED=true scipoptlib
 
-from the root of the SCIP Optimization directory. This will result in the creation of the directory `<path_to_scipopt/lib>` and the shared library `libscipopt.so`.
+from the root of the SCIP Optimization Suite directory. This will result in the creation of the directory `<path_to_scipopt/lib>` and the shared library `libscipopt.so`.
 
-From within this directory, please execute the following command:
+From within the `PySCIPOpt` directory, please execute the following command:
 
     python setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if usesharedlib:
                          include_dirs=[linkincludescip],
                          library_dirs=['lib'],
                          runtime_library_dirs=[os.path.abspath('lib')],
-                         libraries=['scipopt', 'readline', 'z', 'gmp', 'ncurses', 'm'])]
+                         libraries=['scipopt'])]
 else:
    extensions = [Extension('pyscipopt.scip', [os.path.join('pyscipopt', 'scip'+ext)],
                          extra_compile_args=['-UNDEBUG'],


### PR DESCRIPTION
new scipoptlib is aware of its dependencies so we don't need to specify them here