### PR TITLE
set runtime lib dir and use absolute paths for include and lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ install:
   - tar xzf scipoptsuite-$VERSION.tgz
   - cd scipoptsuite-$VERSION
   - make COMP=clang SHARED=true GMP=false READLINE=false ZIMPL=false
-  - make install INSTALLDIR=.. COMP=clang SHARED=true GMP=false READLINE=false ZIMPL=false
+  - make install INSTALLDIR=~/scipdir COMP=clang SHARED=true GMP=false READLINE=false ZIMPL=false
   - cd ..
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib
-  - python setup.py install
+  - env SCIPOPTDIR=~/scipdir python setup.py install
 
 script: py.test tests

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,15 +5,15 @@ PySCIPOpt uses the shared library of the [SCIP Optimization Suite](http://scip.z
 You need to have the library corresponding to your platform (Linux, Windows, OS X) available on your system.
 If the library is not installed in the global path you need to specify its location using the environment variable `SCIPOPTDIR`:
 
- - on Linux and OS X:   
-    `export SCIPOPTDIR=<absolut_path_to_directory>`
+ - on Linux and OS X:  
+    `export SCIPOPTDIR=<path_to_install_dir>`
 
- - on Windows:   
-    `set SCIPOPTDIR=<absolut_path_to_directory>`
+ - on Windows:  
+    `set SCIPOPTDIR=<path_to_install_dir>`
 
 `SCIPOPTDIR` needs to have a subdirectory `lib` that contains the library.
 
-Additionally, if you're building PySCIPOpt from source, i.e. not using the precompiled egg or wheel, you also need to place all SCIP header files into a directory `include` next to `lib`:
+Additionally, if you're building PySCIPOpt from source, i.e. not using the precompiled egg or wheel, you also need to place all SCIP header files into a directory `include` next to `lib` (this is done automatically by `make install INSTALLDIR=$SCIPOPTDIR` of the SCIP Optimization Suite):
 
     SCIPOPTDIR
       > lib
@@ -31,16 +31,13 @@ Installation from PyPI
 
 `pip install pyscipopt`
 
-To be able to use PySCIPOpt with a library that is not located in the standard search path of your machine (`~/lib`, `/usr/local/lib`, etc.) you need to set it accordingly:
-
- - on Linux:  
-    `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SCIPOPTDIR/lib`
+On Windows you need to make sure that the `scipopt` library can be found at runtime by adjusting your `PATH` environment variable:
 
  - on Windows:  
     `set PATH=%PATH%;%SCIPOPTDIR%\lib`
 
- - on OS X:  
-    `export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$SCIPOPTDIR/lib`
+On Linux and OS X this is encoded in the generated PySCIPOpt library and therefore not necessary.
+
 
 
 Building everything form source

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os, platform
 # look for environment variable that specifies path to SCIP Opt lib and headers
 scipoptdir = os.environ.get('SCIPOPTDIR', '')
 
-includedir = os.path.join(scipoptdir, 'include')
+includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
 libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
 
 libname = 'libscipopt' if os.name == 'nt' else 'scipopt'

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,44 @@
 from setuptools import setup, Extension
-import os
+import os, platform
 
 # look for environment variable that specifies path to SCIP Opt lib and headers
 scipoptdir = os.environ.get('SCIPOPTDIR', '')
 
 includedir = os.path.join(scipoptdir, 'include')
-libdir = os.path.join(scipoptdir, 'lib')
+libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
 
 libname = 'libscipopt' if os.name == 'nt' else 'scipopt'
 
 cythonize = True
 
 try:
-    from Cython.Distutils import build_ext
     from Cython.Build import cythonize
 except ImportError:
+    if not os.path.exists(os.path.join('pyscipopt', 'scip.c')):
+        print('Cython is required')
+        quit(1)
     cythonize = False
 
 if not os.path.exists(os.path.join('pyscipopt', 'scip.pyx')):
     cythonize = False
 
-extensions = []
 ext = '.pyx' if cythonize else '.c'
+
+# set runtime libraries
+runtime_library_dirs = []
+extra_link_args = []
+if platform.system() == 'Linux':
+    runtime_library_dirs.append(libdir)
+elif platform.system() == 'Darwin':
+    extra_link_args.append('-Wl,-rpath,'+libdir)
 
 extensions = [Extension('pyscipopt.scip', [os.path.join('pyscipopt', 'scip'+ext)],
                           include_dirs=[includedir],
                           library_dirs=[libdir],
-                          libraries=[libname])]
+                          libraries=[libname],
+                          runtime_library_dirs=runtime_library_dirs,
+                          extra_link_args=extra_link_args
+                          )]
 
 if cythonize:
     extensions = cythonize(extensions)


### PR DESCRIPTION
This avoids having to modify the LD_LIBRARY_DIR, etc.