### PR TITLE
remove -R flag gcc does not understand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, Extension
 import os, platform, sys
 
 # look for environment variable that specifies path to SCIP Opt lib and headers
-scipoptdir = os.environ.get('SCIPOPTDIR', '')
+scipoptdir = os.environ.get('SCIPOPTDIR', '/usr/local')  # assume SCIP shared library is in /usr/local if SCIOPTDIR not set
 includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
 libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
 libname = 'scip'
@@ -27,9 +27,8 @@ ext = '.pyx' if cythonize else '.c'
 # set runtime libraries
 runtime_library_dirs = []
 extra_link_args = []
-if platform.system() == 'Linux':
-    runtime_library_dirs.append(libdir)
-elif platform.system() == 'Darwin':
+
+if platform.system() in ['Darwin', 'Linux']:  # now both Linux and Darwin work like this:
     extra_link_args.append('-Wl,-rpath,'+libdir)
 
 # enable debug mode if requested


### PR DESCRIPTION
On Ubuntu 16.04 LTS
I used cmake to build shared libraries for SCIP and installed them into `/usr/local`,
which SCIP seems to hold as the default install location.

I was trying to install PySCIPOpt via:

```
$ git clone https://github.com/SCIP-Interfaces/PySCIPOpt
$ cd PySCIPOpt/
$ python setup.py build
```

with Anaconda python 2.7 when I got this error:

```
gcc -pthread -B /mnt/data/anaconda2/compiler_compat -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/home/darrenrhea/PySCIPOpt/include -I/mnt/data/anaconda2/include/python2.7 -c src/pyscipopt/scip.c -o build/temp.linux-x86_64-2.7/src/pyscipopt/scip.o

gcc -pthread -shared -B /mnt/data/anaconda2/compiler_compat -L/mnt/data/anaconda2/lib -Wl,-rpath=/mnt/data/anaconda2/lib,--no-as-needed build/temp.linux-x86_64-2.7/src/pyscipopt/scip.o -L/home/darrenrhea/PySCIPOpt/lib -L/mnt/data/anaconda2/lib -R/home/darrenrhea/PySCIPOpt/lib -lscip -lpython2.7 -o build/lib.linux-x86_64-2.7/pyscipopt/scip.so

gcc: error: unrecognized command line option ‘-R’
error: command 'gcc' failed with exit status 1
```

This is my attempt to fix this by doing for Linux what is done for Darwin.  Instead of -R it is now doing `-Wl,-rpath,/usr/local/lib` instead:

```
gcc -pthread -B /mnt/data/anaconda2/compiler_compat -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/local/include -I/mnt/data/anaconda2/include/python2.7 -c src/pyscipopt/scip.c -o build/temp.linux-x86_64-2.7/src/pyscipopt/scip.o
gcc -pthread -shared -B /mnt/data/anaconda2/compiler_compat -L/mnt/data/anaconda2/lib -Wl,-rpath=/mnt/data/anaconda2/lib,--no-as-needed build/temp.linux-x86_64-2.7/src/pyscipopt/scip.o -L/usr/local/lib -L/mnt/data/anaconda2/lib -lscip -lpython2.7 -o build/lib.linux-x86_64-2.7/pyscipopt/scip.so -Wl,-rpath,/usr/local/lib
```

All of the examples found in  the `examples/finished` directory run after making this change to setup.py and doing

```
$ python setup.py build
$ python setup.py install
```

Maybe there is a better way, I don't know.  