### PR TITLE
add access to the data of quadratic constraints

### DIFF
--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -919,6 +919,30 @@ cdef extern from "scip/cons_quadratic.h":
     SCIP_Real SCIPgetLhsQuadratic(SCIP* scip, SCIP_CONS* cons)
     SCIP_Real SCIPgetRhsQuadratic(SCIP* scip, SCIP_CONS* cons)
     SCIP_RETCODE SCIPgetActivityQuadratic(SCIP* scip, SCIP_CONS* cons, SCIP_SOL* sol, SCIP_Real* activity)
+    SCIP_BILINTERM* SCIPgetBilinTermsQuadratic(SCIP* scip, SCIP_CONS* cons)
+    int SCIPgetNBilinTermsQuadratic(SCIP* scip, SCIP_CONS* cons)
+    SCIP_QUADVARTERM* SCIPgetQuadVarTermsQuadratic(SCIP* scip, SCIP_CONS* cons)
+    int SCIPgetNQuadVarTermsQuadratic(SCIP* scip, SCIP_CONS* cons)
+    SCIP_VAR** SCIPgetLinearVarsQuadratic(SCIP* scip, SCIP_CONS* cons)
+    SCIP_Real* SCIPgetCoefsLinearVarsQuadratic(SCIP* scip, SCIP_CONS* cons)
+    int SCIPgetNLinearVarsQuadratic(SCIP* scip, SCIP_CONS* cons)
+
+    ctypedef struct SCIP_QUADVAREVENTDATA:
+        pass
+
+    ctypedef struct SCIP_QUADVARTERM:
+        SCIP_VAR* var
+        SCIP_Real lincoef
+        SCIP_Real sqrcoef
+        int nadjbilin
+        int adjbilinsize
+        int* adjbilin
+        SCIP_QUADVAREVENTDATA* eventdata
+
+    ctypedef struct SCIP_BILINTERM:
+        SCIP_VAR* var1
+        SCIP_VAR* var2
+        SCIP_Real coef
 
 cdef extern from "scip/cons_sos1.h":
     SCIP_RETCODE SCIPcreateConsSOS1(SCIP* scip,

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -358,6 +358,23 @@ cdef extern from "scip/scip.h":
     ctypedef struct SCIP_EXPRDATA_MONOMIAL:
         pass
 
+    ctypedef struct SCIP_QUADVAREVENTDATA:
+        pass
+
+    ctypedef struct SCIP_QUADVARTERM:
+        SCIP_VAR* var
+        SCIP_Real lincoef
+        SCIP_Real sqrcoef
+        int nadjbilin
+        int adjbilinsize
+        int* adjbilin
+        SCIP_QUADVAREVENTDATA* eventdata
+
+    ctypedef struct SCIP_BILINTERM:
+        SCIP_VAR* var1
+        SCIP_VAR* var2
+        SCIP_Real coef
+
     # General SCIP Methods
     SCIP_RETCODE SCIPcreate(SCIP** scip)
     SCIP_RETCODE SCIPfree(SCIP** scip)
@@ -926,23 +943,6 @@ cdef extern from "scip/cons_quadratic.h":
     SCIP_VAR** SCIPgetLinearVarsQuadratic(SCIP* scip, SCIP_CONS* cons)
     SCIP_Real* SCIPgetCoefsLinearVarsQuadratic(SCIP* scip, SCIP_CONS* cons)
     int SCIPgetNLinearVarsQuadratic(SCIP* scip, SCIP_CONS* cons)
-
-    ctypedef struct SCIP_QUADVAREVENTDATA:
-        pass
-
-    ctypedef struct SCIP_QUADVARTERM:
-        SCIP_VAR* var
-        SCIP_Real lincoef
-        SCIP_Real sqrcoef
-        int nadjbilin
-        int adjbilinsize
-        int* adjbilin
-        SCIP_QUADVAREVENTDATA* eventdata
-
-    ctypedef struct SCIP_BILINTERM:
-        SCIP_VAR* var1
-        SCIP_VAR* var2
-        SCIP_Real coef
 
 cdef extern from "scip/cons_sos1.h":
     SCIP_RETCODE SCIPcreateConsSOS1(SCIP* scip,

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -460,6 +460,7 @@ cdef class Constraint:
         return SCIPconsIsStickingAtNode(self.cons)
 
     def isQuadratic(self):
+        """Retrieve True if constraint is quadratic"""
         constype = bytes(SCIPconshdlrGetName(SCIPconsGetHdlr(self.cons))).decode('UTF-8')
         return constype == 'quadratic'
 
@@ -1548,8 +1549,15 @@ cdef class Model:
         return Constraint.create(transcons)
 
     def getBilintermsQuadratic(self, Constraint cons):
+        """Retrieve bilinear terms of a quadratic constraint.
+
+        :param Constraint cons: constraint
+
+        """
         cdef SCIP_BILINTERM* _bilinterms
         cdef int _nbilinterms
+
+        assert cons.isQuadratic()
 
         _bilinterms = SCIPgetBilinTermsQuadratic(self._scip, cons.cons)
         _nbilinterms = SCIPgetNBilinTermsQuadratic(self._scip, cons.cons)
@@ -1561,8 +1569,15 @@ cdef class Model:
         return (vars1,vars2,coefs)
 
     def getQuadtermsQuadratic(self, Constraint cons):
+        """Retrieve quadratic terms of a quadratic constraint.
+
+        :param Constraint cons: constraint
+
+        """
         cdef SCIP_QUADVARTERM* _quadterms
         cdef int _nquadterms
+
+        assert cons.isQuadratic()
 
         _quadterms = SCIPgetQuadVarTermsQuadratic(self._scip, cons.cons)
         _nquadterms = SCIPgetNQuadVarTermsQuadratic(self._scip, cons.cons)
@@ -1574,9 +1589,16 @@ cdef class Model:
         return (vars,sqrcoefs,lincoefs)
 
     def getLintermsQuadratic(self, Constraint cons):
+        """Retrieve linear terms of a quadratic constraint.
+
+        :param Constraint cons: constraint
+
+        """
         cdef SCIP_VAR** _linvars
         cdef SCIP_Real* _lincoefs
         cdef int _nlinvars
+
+        assert cons.isQuadratic()
 
         _linvars = SCIPgetLinearVarsQuadratic(self._scip, cons.cons)
         _lincoefs = SCIPgetCoefsLinearVarsQuadratic(self._scip, cons.cons)

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -459,6 +459,11 @@ cdef class Constraint:
         """Retrieve True if constraint is only locally valid or not added to any (sub)problem"""
         return SCIPconsIsStickingAtNode(self.cons)
 
+    def isLinear(self):
+        """Retrieve True if constraint is linear"""
+        constype = bytes(SCIPconshdlrGetName(SCIPconsGetHdlr(self.cons))).decode('UTF-8')
+        return constype == 'linear'
+
     def isQuadratic(self):
         """Retrieve True if constraint is quadratic"""
         constype = bytes(SCIPconshdlrGetName(SCIPconsGetHdlr(self.cons))).decode('UTF-8')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -18,6 +18,7 @@ def test_model():
 
     # add some constraint
     c = s.addCons(x + 2 * y >= 1.0)
+    assert c.isLinear()
     s.chgLhs(c, 5.0)
     s.chgRhs(c, 6.0)
 

--- a/tests/test_nonlinear.py
+++ b/tests/test_nonlinear.py
@@ -263,3 +263,25 @@ def test_gastrans():
         pytest.skip()
 
     assert abs(scip.getPrimalbound() - 89.08584) < 1.0e-9
+
+def test_quad_coeffs():
+    """test coefficient access method for quadratic constraints"""
+    scip = Model()
+    x = scip.addVar()
+    y = scip.addVar()
+    z = scip.addVar()
+
+    c = scip.addCons(2*x*y + 0.5*x**2 + 4*z >= 10)
+    assert c.isQuadratic()
+
+    bilinterms, quadterms, linterms = scip.getTermsQuadratic(c)
+
+    assert bilinterms[0][0].name == x.name
+    assert bilinterms[0][1].name == y.name
+    assert bilinterms[0][2] == 2
+
+    assert quadterms[0][0].name == x.name
+    assert quadterms[0][1] == 0.5
+
+    assert linterms[0][0].name == z.name
+    assert linterms[0][1] == 4


### PR DESCRIPTION
Right now, it is not possible to access the data of, e.g., quadratic constraints. I have added some functions for this and also added a convenient function `isQuadratic` to check whether an constraint is actually handled by the quadratic constraint handler or not.