### PR TITLE
warn if problem was not solved before

### DIFF
--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -1514,6 +1514,8 @@ cdef class Model:
 
     def getSlack(self, Constraint cons, Solution sol = None, side = None):
         """Retrieve slack of given constraint.
+        Can only be called after solving is completed.
+
 
         :param Constraint cons: linear or quadratic constraint
         :param Solution sol: solution to compute slack of, None to use current node's solution (Default value = None)
@@ -1522,6 +1524,10 @@ cdef class Model:
         """
         cdef SCIP_Real activity
         cdef SCIP_SOL* scip_sol
+
+
+        if not self.getStage() >= SCIP_STAGE_SOLVING:
+            raise Warning("method cannot be called before problem is solved")
 
         if isinstance(sol, Solution):
             scip_sol = sol.sol

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -1484,6 +1484,7 @@ cdef class Model:
 
     def getActivity(self, Constraint cons, Solution sol = None):
         """Retrieve activity of given constraint.
+        Can only be called after solving is completed.
 
         :param Constraint cons: linear or quadratic constraint
         :param Solution sol: solution to compute activity of, None to use current node's solution (Default value = None)
@@ -1491,6 +1492,9 @@ cdef class Model:
         """
         cdef SCIP_Real activity
         cdef SCIP_SOL* scip_sol
+
+        if not self.getStage() >= SCIP_STAGE_SOLVING:
+            raise Warning("method cannot be called before problem is solved")
 
         if isinstance(sol, Solution):
             scip_sol = sol.sol

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -25,15 +25,6 @@ def test_model():
     assert s.getLhs(c) == 5.0
     assert s.getRhs(c) == 6.0
 
-    badsolution = s.createSol()
-    s.setSolVal(badsolution, x, 2.0)
-    s.setSolVal(badsolution, y, 2.0)
-    assert s.getSlack(c, badsolution) == 0.0
-    assert s.getSlack(c, badsolution, 'lhs') == 1.0
-    assert s.getSlack(c, badsolution, 'rhs') == 0.0
-    assert s.getActivity(c, badsolution) == 6.0
-    s.freeSol(badsolution)
-
     # solve problem
     s.optimize()
 


### PR DESCRIPTION
When we access `getActivity` before `optimize`, we can a segmentation fault:
```
In [1]: from pyscipopt import Model
In [2]: M = Model()
In [3]: M.addCons(M.addVar()<=10)
Out[3]: c1
In [4]: M.getActivity(_)
Segmentation fault
```
This patch catches it, and gives a warning instead.