### PR TITLE
fix for conshdlr and adds expr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
 libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
 libname = 'scip'
 
+print(scipoptdir)
+
 cythonize = True
 
 packagedir = os.path.join('src', 'pyscipopt')

--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -12,6 +12,7 @@ from pyscipopt.scip      import Pricer
 from pyscipopt.scip      import Prop
 from pyscipopt.scip      import Sepa
 from pyscipopt.scip      import LP
+from pyscipopt.scip      import Expr
 from pyscipopt.scip      import quicksum
 from pyscipopt.scip      import exp
 from pyscipopt.scip      import log

--- a/src/pyscipopt/conshdlr.pxi
+++ b/src/pyscipopt/conshdlr.pxi
@@ -40,7 +40,7 @@ cdef class Conshdlr:
     def conssepasol(self, constraints, nusefulconss, solution):
         return {}
 
-    def consenfolp(self, solution, constraints, nusefulconss, solinfeasible):
+    def consenfolp(self, constraints, nusefulconss, solinfeasible):
         print("python error in consenfolp: this method needs to be implemented")
         return {}
 


### PR DESCRIPTION
Adds the Expr object to the public interface. This is inline with the Gurobi python interface. Also, the conshdlr enfolp callback is corrected. The parameters were incorrect.