### PR TITLE
Logical connectives

### DIFF
--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -13,6 +13,7 @@ from pyscipopt.scip      import Prop
 from pyscipopt.scip      import Sepa
 from pyscipopt.scip      import LP
 from pyscipopt.scip      import quicksum
+from pyscipopt.scip      import quickmul
 from pyscipopt.scip      import exp
 from pyscipopt.scip      import log
 from pyscipopt.scip      import sqrt

--- a/src/pyscipopt/expr.pxi
+++ b/src/pyscipopt/expr.pxi
@@ -357,6 +357,15 @@ def quicksum(termlist):
         result += term
     return result
 
+def quickmul(termlist):
+    '''multiply linear expressions and constants by avoiding intermediate 
+    data structures and multiplying terms inplace
+    '''
+    result = Expr() + 1
+    for term in termlist:
+        result *= term
+    return result
+
 
 class Op:
     const = 'const'

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1051,6 +1051,42 @@ cdef extern from "scip/cons_sos2.h":
                                    SCIP_CONS* cons,
                                    SCIP_VAR* var)
 
+cdef extern from "scip/cons_and.h":
+    SCIP_RETCODE SCIPcreateConsAnd(SCIP* scip,
+                                         SCIP_CONS** cons,
+                                         const char* name,
+                                         SCIP_VAR* resvar,
+                                         int nvars,
+                                         SCIP_VAR** vars,
+                                         SCIP_Bool initial,
+                                         SCIP_Bool separate,
+                                         SCIP_Bool enforce,
+                                         SCIP_Bool check,
+                                         SCIP_Bool propagate,
+                                         SCIP_Bool local,
+                                         SCIP_Bool modifiable,
+                                         SCIP_Bool dynamic,
+                                         SCIP_Bool removable,
+                                         SCIP_Bool stickingatnode)
+
+cdef extern from "scip/cons_or.h":
+    SCIP_RETCODE SCIPcreateConsOr(SCIP* scip,
+                                         SCIP_CONS** cons,
+                                         const char* name,
+                                         SCIP_VAR* resvar,
+                                         int nvars,
+                                         SCIP_VAR** vars,
+                                         SCIP_Bool initial,
+                                         SCIP_Bool separate,
+                                         SCIP_Bool enforce,
+                                         SCIP_Bool check,
+                                         SCIP_Bool propagate,
+                                         SCIP_Bool local,
+                                         SCIP_Bool modifiable,
+                                         SCIP_Bool dynamic,
+                                         SCIP_Bool removable,
+                                         SCIP_Bool stickingatnode)
+
 cdef extern from "blockmemshell/memory.h":
     void BMScheckEmptyMemory()
     long long BMSgetMemoryUsed()

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -1442,6 +1442,84 @@ cdef class Model:
         PY_SCIP_CALL(SCIPaddCons(self._scip, scip_cons))
         return Constraint.create(scip_cons)
 
+    def addConsAnd(self, vars, resvar=None, name="ANDcons",
+            initial=True, separate=True, enforce=True, check=True,
+            propagate=True, local=False, modifiable=False, dynamic=False,
+            removable=False, stickingatnode=False):
+        """Add an AND-constraint.
+        :param vars: list of variables to be included
+        :param name: name of the constraint (Default value = "ANDcons")
+        :param initial: should the LP relaxation of constraint be in the initial LP? (Default value = True)
+        :param separate: should the constraint be separated during LP processing? (Default value = True)
+        :param enforce: should the constraint be enforced during node processing? (Default value = True)
+        :param check: should the constraint be checked for feasibility? (Default value = True)
+        :param propagate: should the constraint be propagated during node processing? (Default value = True)
+        :param local: is the constraint only valid locally? (Default value = False)
+        :param modifiable: is the constraint modifiable (subject to column generation)? (Default value = False)
+        :param dynamic: is the constraint subject to aging? (Default value = False)
+        :param removable: should the relaxation be removed from the LP due to aging or cleanup? (Default value = False)
+        :param stickingatnode: should the constraint always be kept at the node where it was added, even if it may be moved to a more global node? (Default value = False)
+        """
+        cdef SCIP_CONS* scip_cons
+
+        nvars = len(vars)
+
+        _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
+        for idx, var in enumerate(vars):
+            _vars[idx] = (<Variable>var).var
+        _resVar = (<Variable>resvar).var if resvar is not None else NULL
+
+        PY_SCIP_CALL(SCIPcreateConsAnd(self._scip, &scip_cons, str_conversion(name), _resVar, nvars, _vars,
+            initial, separate, enforce, check, propagate, local, modifiable, dynamic, removable, stickingatnode))
+
+        PY_SCIP_CALL(SCIPaddCons(self._scip, scip_cons))
+        pyCons = Constraint.create(scip_cons)
+        PY_SCIP_CALL(SCIPreleaseCons(self._scip, &scip_cons))
+
+        free(_vars)
+        free(_resVar)
+
+        return pyCons
+
+    def addConsOr(self, vars, resvar=None, name="ORcons",
+            initial=True, separate=True, enforce=True, check=True,
+            propagate=True, local=False, modifiable=False, dynamic=False,
+            removable=False, stickingatnode=False):
+        """Add an OR-constraint.
+        :param vars: list of variables to be included
+        :param name: name of the constraint (Default value = "ORcons")
+        :param initial: should the LP relaxation of constraint be in the initial LP? (Default value = True)
+        :param separate: should the constraint be separated during LP processing? (Default value = True)
+        :param enforce: should the constraint be enforced during node processing? (Default value = True)
+        :param check: should the constraint be checked for feasibility? (Default value = True)
+        :param propagate: should the constraint be propagated during node processing? (Default value = True)
+        :param local: is the constraint only valid locally? (Default value = False)
+        :param modifiable: is the constraint modifiable (subject to column generation)? (Default value = False)
+        :param dynamic: is the constraint subject to aging? (Default value = False)
+        :param removable: should the relaxation be removed from the LP due to aging or cleanup? (Default value = False)
+        :param stickingatnode: should the constraint always be kept at the node where it was added, even if it may be moved to a more global node? (Default value = False)
+        """
+        cdef SCIP_CONS* scip_cons
+
+        nvars = len(vars)
+
+        _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
+        for idx, var in enumerate(vars):
+            _vars[idx] = (<Variable>var).var
+        _resVar = (<Variable>resvar).var if resvar is not None else NULL
+
+        PY_SCIP_CALL(SCIPcreateConsOr(self._scip, &scip_cons, str_conversion(name), _resVar, nvars, _vars,
+            initial, separate, enforce, check, propagate, local, modifiable, dynamic, removable, stickingatnode))
+
+        PY_SCIP_CALL(SCIPaddCons(self._scip, scip_cons))
+        pyCons = Constraint.create(scip_cons)
+        PY_SCIP_CALL(SCIPreleaseCons(self._scip, &scip_cons))
+
+        free(_vars)
+        free(_resVar)
+
+        return pyCons
+
     def addConsCardinality(self, consvars, cardval, indvars=None, weights=None, name="CardinalityCons",
                 initial=True, separate=True, enforce=True, check=True,
                 propagate=True, local=False, dynamic=False,

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -1442,12 +1442,13 @@ cdef class Model:
         PY_SCIP_CALL(SCIPaddCons(self._scip, scip_cons))
         return Constraint.create(scip_cons)
 
-    def addConsAnd(self, vars, resvar=None, name="ANDcons",
+    def addConsAnd(self, vars, resvar, name="ANDcons",
             initial=True, separate=True, enforce=True, check=True,
             propagate=True, local=False, modifiable=False, dynamic=False,
             removable=False, stickingatnode=False):
         """Add an AND-constraint.
-        :param vars: list of variables to be included
+        :param vars: list of BINARY variables to be included (operators)
+        :param resvar: BINARY variable (resultant)
         :param name: name of the constraint (Default value = "ANDcons")
         :param initial: should the LP relaxation of constraint be in the initial LP? (Default value = True)
         :param separate: should the constraint be separated during LP processing? (Default value = True)
@@ -1467,7 +1468,7 @@ cdef class Model:
         _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
         for idx, var in enumerate(vars):
             _vars[idx] = (<Variable>var).var
-        _resVar = (<Variable>resvar).var if resvar is not None else NULL
+        _resVar = (<Variable>resvar).var
 
         PY_SCIP_CALL(SCIPcreateConsAnd(self._scip, &scip_cons, str_conversion(name), _resVar, nvars, _vars,
             initial, separate, enforce, check, propagate, local, modifiable, dynamic, removable, stickingatnode))
@@ -1477,16 +1478,16 @@ cdef class Model:
         PY_SCIP_CALL(SCIPreleaseCons(self._scip, &scip_cons))
 
         free(_vars)
-        free(_resVar)
 
         return pyCons
 
-    def addConsOr(self, vars, resvar=None, name="ORcons",
+    def addConsOr(self, vars, resvar, name="ORcons",
             initial=True, separate=True, enforce=True, check=True,
             propagate=True, local=False, modifiable=False, dynamic=False,
             removable=False, stickingatnode=False):
         """Add an OR-constraint.
-        :param vars: list of variables to be included
+        :param vars: list of BINARY variables to be included (operators)
+        :param resvar: BINARY variable (resultant)
         :param name: name of the constraint (Default value = "ORcons")
         :param initial: should the LP relaxation of constraint be in the initial LP? (Default value = True)
         :param separate: should the constraint be separated during LP processing? (Default value = True)
@@ -1506,7 +1507,7 @@ cdef class Model:
         _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
         for idx, var in enumerate(vars):
             _vars[idx] = (<Variable>var).var
-        _resVar = (<Variable>resvar).var if resvar is not None else NULL
+        resVar = (<Variable>resvar).var
 
         PY_SCIP_CALL(SCIPcreateConsOr(self._scip, &scip_cons, str_conversion(name), _resVar, nvars, _vars,
             initial, separate, enforce, check, propagate, local, modifiable, dynamic, removable, stickingatnode))
@@ -1516,7 +1517,6 @@ cdef class Model:
         PY_SCIP_CALL(SCIPreleaseCons(self._scip, &scip_cons))
 
         free(_vars)
-        free(_resVar)
 
         return pyCons
 

--- a/tests/test_connectives.py
+++ b/tests/test_connectives.py
@@ -1,0 +1,95 @@
+from pyscipopt import Model
+
+################################################################################
+#
+# Testing AND/OR constraints
+#   check whether any error is raised
+# see http://scip.zib.de/doc-5.0.1/html/cons__and_8c.php
+#   for resultant and operators definition
+# CAVEAT: ONLY binary variables are allowed
+#   Integer and continous variables behave unexpectedly (due to SCIP?)
+# TBI: automatic assertion of expected resultant VS optimal resultant
+#   (visual inspection at the moment)
+# TBI: implement and test XOR constraint
+#
+################################################################################
+
+### AUXILIARY ###
+def setModel(vtype="B", name=None, imax=2):
+    if name is None: name = "model"
+    m = Model(name)
+    m.hideOutput()
+    i = 0
+    m.addVar("r", vtype)
+    while i < imax:
+        m.addVar("v%s" % i, vtype)
+        i+=1
+    return m
+
+def getVarByName(m, name):
+    try:
+        return [v for v in m.getVars() if name == v.name][0]
+    except IndexError:
+        return None
+
+def getAllVarsByName(m, name):
+    try:
+        return [v for v in m.getVars() if name in v.name]
+    except IndexError:
+        return []
+
+
+def setConss(m, vtype="B", val=0, imax=1):
+    i = 0
+    while i < imax:
+        vi = getVarByName(m,"v%s" % i)
+        m.addCons(vi == val, vtype)
+        i+=1
+    return
+
+def printOutput(m):
+    status = m.getStatus()
+    r = getVarByName(m,"r")
+    rstr = "%d" % round(m.getVal(r))
+    vs = getAllVarsByName(m, "v")
+    vsstr = "".join(["%d" % round(m.getVal(v)) for v in vs])
+    print "Status: %s, resultant: %s, operators: %s" % (status, rstr, vsstr)
+
+### TEST ###
+def test_connective(m, connective, sense="min"):
+    try:
+        r = getVarByName(m,"r")
+        vs = getAllVarsByName(m, "v")
+        ### addConsAnd/Or method (Xor: TBI) ###
+        _m_method = getattr(m, "addCons%s" % connective.capitalize())
+        _m_method(vs,r)
+        m.setObjective(r, sense="%simize" % sense)
+        m.optimize()
+        printOutput(m)
+        return True
+    except Exception as e:
+        print "%s: %s" % (e.__class__.__name__, e)
+        return False
+
+### MAIN ###
+if __name__ == "__main__":
+    from itertools import product
+    lvtype = ["B"]#,"I","C"] #I and C may raise errors: see preamble
+    lconnective = ["and", "or"]
+    lsense = ["min","max"]
+    lnoperators = [2,20,200]
+    lvconss = [0, 1]
+    lnconss = [1, 2, None]
+    cases = list(product(lnoperators, lvtype, lconnective, lsense, lvconss, lnconss))
+    for c in cases:
+        noperators, vtype, connective, sense, vconss, nconss = c
+        if nconss == None: nconss = noperators
+        c = (noperators, vtype, connective, sense, vconss, nconss)
+        m = setModel(vtype, connective, noperators)
+        setConss(m,vtype, vconss, nconss)
+        teststr = ', '.join(list(str(ic) for ic in c))
+        #print "Test: %s" % teststr
+        print "Test: %3d operators of vtype %s; %s-constraint and sense %s; %d as constraint for %3d operator/s" % c
+        success = test_connective(m, connective, sense) 
+        print "Is test successful? %s" % success
+        print

--- a/tests/test_quickmul.py
+++ b/tests/test_quickmul.py
@@ -1,0 +1,41 @@
+from pyscipopt import Model, quickmul
+from pyscipopt.scip import CONST
+from operator import mul
+
+def test_quickmul_model():
+    m = Model("quickmul")
+    x = m.addVar("x")
+    y = m.addVar("y")
+    z = m.addVar("z")
+    c = 2.3
+
+    q = quickmul([x,y,z,c]) == 0.0
+    s = reduce(mul,[x,y,z,c],1) == 0.0
+
+    assert(q.expr.terms == s.expr.terms)
+
+def test_quickmul():
+    empty = quickmul(1 for i in [])
+    assert len(empty.terms) == 1
+    assert CONST in empty.terms
+
+def test_largequadratic():
+    # inspired from performance issue on
+    # http://stackoverflow.com/questions/38434300
+
+    m = Model("dense_quadratic")
+    dim = 20
+    x = [m.addVar("x_%d" % i) for i in range(dim)]
+    expr = quickmul((i+j+1)*x[i]*x[j]
+                    for i in range(dim)
+                    for j in range(dim))
+    cons = expr <= 1.0
+    #                              upper triangle,     diagonal
+    assert cons.expr.degree() == 2*dim*dim
+    m.addCons(cons)
+    # TODO: what can we test beyond the lack of crashes?
+
+if __name__ == "__main__":
+    test_quickmul()
+    test_quickmul_model()
+    test_largequadratic()


### PR DESCRIPTION
Dear SCIP workers, greetings.

The aim of this pull request is to **introduce logical connectives**[1] AND and OR[2] in PySCIPOpt.
For the moment being, I added some test without checking the resultant's value.
Please be direct whether some does not fulfill any policy here.[3] Any comment is much appreciated.

Best wishes.

[1] about nomenclature: since variables are called "operators" in SCIP (see [here](http://scip.zib.de/doc-5.0.1/html/cons__and_8h.php)), I called AND and OR "connectives".
[2] XOR is TBI since its signature is not consistent with AND/OR.
[3] a CONTRIBUTING.md / CONTRIBUTING file could help the project.