### PR TITLE
CONTRIBUTING.rst: pep8

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,3 +13,5 @@ Code contributions are very welcome and should comply to a few rules:
 #. New features should be covered by the tests, so please extend `tests <tests>`__
 
 #. New code should be documented in the same style as the rest of the code
+
+#. New code should be `pep8-compliant <https://www.python.org/dev/peps/pep-0008/>`__. Help yourself with the `style guide checker <https://pypi.org/project/pep8/>`__.


### PR DESCRIPTION
As seen [here](https://github.com/SCIP-Interfaces/PySCIPOpt/commit/85f3198e1c61e07baaa708aae9014b1b8634c725), contributing must follow [pep8](https://www.python.org/dev/peps/pep-0008/). I add the remark in `CONTRIBUTING.rst`.