### PR TITLE
String conversion in setStringParam()

### DIFF
--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -2708,7 +2708,8 @@ cdef class Model:
 
         """
         n = str_conversion(name)
-        PY_SCIP_CALL(SCIPsetStringParam(self._scip, n, value))
+        v = str_conversion(value)
+        PY_SCIP_CALL(SCIPsetStringParam(self._scip, n, v))
 
     def setParam(self, name, value):
         """Set a parameter with value in int, bool, real, long, char or str.


### PR DESCRIPTION
Safety check both name AND value before calling SCIPsetStringParam().