### PR TITLE
adds BendersDecomp class and update lower bound function

### DIFF
--- a/src/pyscipopt/benders.pxi
+++ b/src/pyscipopt/benders.pxi
@@ -1,5 +1,6 @@
 cdef class Benders:
     cdef public Model model
+    cdef public str name
 
     def bendersfree(self):
         pass

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -896,6 +896,7 @@ cdef extern from "scip/scip.h":
     SCIP_RETCODE SCIPfreeBendersSubproblem(SCIP* scip, SCIP_BENDERS* benders, int probnumber)
     int SCIPgetNActiveBenders(SCIP* scip)
     SCIP_BENDERS** SCIPgetBenders(SCIP* scip)
+    void SCIPbendersUpdateSubproblemLowerbound(SCIP_BENDERS* benders, int probnumber, SCIP_Real lowerbound)
 
     # Numerical Methods
     SCIP_Real SCIPinfinity(SCIP* scip)

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -2170,7 +2170,7 @@ cdef class Model:
                 PY_SCIP_CALL(SCIPfreeBendersSubproblem(self._scip, _benders[i],
                     j))
 
-    def updateBendersLowerbounds(self, lowerbounds, Benders benders = None):
+    def updateBendersLowerbounds(self, lowerbounds, Benders benders=None):
         """"updates the subproblem lower bounds for benders using
         the lowerbounds dict. If benders is None, then the default
         Benders' decomposition is updated

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -2114,7 +2114,7 @@ cdef class Model:
         subproblems -- a single Model instance or dictionary of Model instances
         """
         cdef SCIP** subprobs
-        cdef SCIP_BENDERS* scipbenders
+        cdef SCIP_BENDERS* benders
 
         # checking whether subproblems is a dictionary
         if isinstance(subproblems, dict):
@@ -2136,8 +2136,8 @@ cdef class Model:
 
         # creating the default Benders' decomposition
         PY_SCIP_CALL(SCIPcreateBendersDefault(self._scip, subprobs, nsubproblems))
-        scipbenders = SCIPfindBenders(self._scip, "default")
-        pyBenders = BendersDecomp.create(scipbenders)
+        benders = SCIPfindBenders(self._scip, "default")
+        pyBenders = BendersDecomp.create(benders)
 
         # activating the Benders' decomposition constraint handlers
         self.setBoolParam("constraints/benderslp/active", True)


### PR DESCRIPTION
A Benders' decomposition class has been added to handle the functions that are directly related to the Benders' decomposition framework of SCIP. These are the functions that only take a Benders' pointer and no SCIP pointer.

In addition, the update lower bound function has been added so that a user can provide a lower bound on the auxiliary variables before solving the problem.