### PR TITLE
fix ZeroDivisionError

### DIFF
--- a/src/pyscipopt/expr.pxi
+++ b/src/pyscipopt/expr.pxi
@@ -545,7 +545,7 @@ cdef class GenExpr:
         divisor = buildGenExprObj(other)
         # we can't divide by 0
         if divisor.getOp() == Operator.const and divisor.number == 0.0:
-            raise ValueError("cannot divide by 0")
+            raise ZeroDivisionError("cannot divide by 0")
         return self * divisor**(-1)
 
     def __rdiv__(self, other):
@@ -557,7 +557,7 @@ cdef class GenExpr:
         divisor = buildGenExprObj(other)
         # we can't divide by 0
         if divisor.getOp() == Operator.const and divisor.number == 0.0:
-            raise ValueError("cannot divide by 0")
+            raise ZeroDivisionError("cannot divide by 0")
         return self * divisor**(-1)
 
     def __rtruediv__(self, other):

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -51,7 +51,7 @@ def test_upgrade(model):
     assert isinstance(log(expr), GenExpr)
     assert isinstance(exp(expr), GenExpr)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ZeroDivisionError):
         expr /= 0.0
 
 def test_genexpr_op_expr(model):


### PR DESCRIPTION
On top of #214 :
- Change `ValueError` -> `ZeroDivisionError` when dividing by 0.
- Change test accordingly.