### PR TITLE
Additional functionality for setting up and solving Benders' subproblems

### DIFF
--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -31,3 +31,4 @@ from pyscipopt.scip      import PY_SCIP_HEURTIMING   as SCIP_HEURTIMING
 from pyscipopt.scip      import PY_SCIP_EVENTTYPE    as SCIP_EVENTTYPE
 from pyscipopt.scip      import PY_SCIP_LPSOLSTAT    as SCIP_LPSOLSTAT
 from pyscipopt.scip      import PY_SCIP_BRANCHDIR    as SCIP_BRANCHDIR
+from pyscipopt.scip      import PY_SCIP_BENDERSENFOTYPE as SCIP_BENDERSENFOTYPE

--- a/src/pyscipopt/benders.pxi
+++ b/src/pyscipopt/benders.pxi
@@ -136,8 +136,7 @@ cdef SCIP_RETCODE PyBendersPresubsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_
     if sol == NULL:
         solution = None
     else:
-        solution = Solution()
-        solution.sol = sol
+        solution = Solution.create(sol)
     enfotype = type
     result_dict = PyBenders.benderspresubsolve(solution, enfotype, checkint)
     skipsolve[0] = result_dict.get("skipsolve", False)
@@ -151,8 +150,7 @@ cdef SCIP_RETCODE PyBendersSolvesubconvex (SCIP* scip, SCIP_BENDERS* benders, SC
     if sol == NULL:
         solution = None
     else:
-        solution = Solution()
-        solution.sol = sol
+        solution = Solution.create(sol)
     result_dict = PyBenders.benderssolvesubconvex(solution, probnumber, onlyconvex)
     objective[0] = result_dict.get("objective", 1e+20)
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
@@ -165,8 +163,7 @@ cdef SCIP_RETCODE PyBendersSolvesub (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL
     if sol == NULL:
         solution = None
     else:
-        solution = Solution()
-        solution.sol = sol
+        solution = Solution.create(sol)
     result_dict = PyBenders.benderssolvesub(solution, probnumber)
     objective[0] = result_dict.get("objective", 1e+20)
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
@@ -181,8 +178,7 @@ cdef SCIP_RETCODE PyBendersPostsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SO
     if sol == NULL:
         solution = None
     else:
-        solution = Solution()
-        solution.sol = sol
+        solution = Solution.create(sol)
     enfotype = type
     mergecandidates = []
     for i in range(nmergecands):

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -2610,8 +2610,8 @@ cdef class Model:
         cdef SCIP_BENDERS* scip_benders
         cdef SCIP_SOL* scip_sol
 
-        if isinstance(sol, Solution):
-            scip_sol = sol.sol
+        if isinstance(solution, Solution):
+            scip_sol = solution.sol
         else:
             scip_sol = NULL
 
@@ -2621,9 +2621,9 @@ cdef class Model:
             n = str_conversion(benders.name)
             scip_benders = SCIPfindBenders(self._scip, n)
 
-        PY_SCIP_CALL(SCIPsetupBendersSubproblem(self._scip, scip_benders, scip_sol, probnumber)
+        PY_SCIP_CALL(SCIPsetupBendersSubproblem(self._scip, scip_benders, scip_sol, probnumber))
 
-    def solveBendersSubproblem(self, probnumber, enfotype, solvecip, Benders benders = None, Solution solution = None)
+    def solveBendersSubproblem(self, probnumber, enfotype, solvecip, Benders benders = None, Solution solution = None):
         """ solves the Benders' decomposition subproblem. The convex relaxation will be solved unless
         the parameter solvecip is set to True.
 
@@ -2636,11 +2636,12 @@ cdef class Model:
         """
 
         cdef SCIP_BENDERS* scip_benders
+        cdef SCIP_SOL* scip_sol
         cdef SCIP_Real objective
         cdef SCIP_Bool infeasible
 
-        if isinstance(sol, Solution):
-            scip_sol = sol.sol
+        if isinstance(solution, Solution):
+            scip_sol = solution.sol
         else:
             scip_sol = NULL
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -203,6 +203,13 @@ cdef class PY_SCIP_BRANCHDIR:
     FIXED     = SCIP_BRANCHDIR_FIXED
     AUTO      = SCIP_BRANCHDIR_AUTO
 
+cdef class PY_SCIP_BENDERSENFOTYPE:
+    LP     = SCIP_BENDERSENFOTYPE_LP
+    RELAX  = SCIP_BENDERSENFOTYPE_RELAX
+    PSEUDO = SCIP_BENDERSENFOTYPE_PSEUDO
+    CHECK  = SCIP_BENDERSENFOTYPE_CHECK
+
+
 def PY_SCIP_CALL(SCIP_RETCODE rc):
     if rc == SCIP_OKAY:
         pass
@@ -2591,6 +2598,62 @@ cdef class Model:
         n = str_conversion(name)
         benders = SCIPfindBenders(self._scip, n)
         PY_SCIP_CALL(SCIPaddBendersSubproblem(self._scip, benders, (<Model>subproblem)._scip))
+
+    def setupBendersSubproblem(self, probnumber, Benders benders = None, Solution solution = None):
+        """ sets up the Benders' subproblem given the master problem solution
+
+        Keyword arguments:
+        probnumber -- the index of the problem that is to be set up
+        benders -- the Benders' decomposition to which the subproblem belongs to
+        solution -- the master problem solution that is used for the set up, if None, then the LP solution is used
+        """
+        cdef SCIP_BENDERS* scip_benders
+        cdef SCIP_SOL* scip_sol
+
+        if isinstance(sol, Solution):
+            scip_sol = sol.sol
+        else:
+            scip_sol = NULL
+
+        if benders is None:
+            scip_benders = SCIPfindBenders(self._scip, "default")
+        else:
+            n = str_conversion(benders.name)
+            scip_benders = SCIPfindBenders(self._scip, n)
+
+        PY_SCIP_CALL(SCIPsetupBendersSubproblem(self._scip, scip_benders, scip_sol, probnumber)
+
+    def solveBendersSubproblem(self, probnumber, enfotype, solvecip, Benders benders = None, Solution solution = None)
+        """ solves the Benders' decomposition subproblem. The convex relaxation will be solved unless
+        the parameter solvecip is set to True.
+
+        Keyword arguments:
+        probnumber -- the index of the problem that is to be set up
+        enfotype -- the enforcement type used for solving the subproblem. Either LP, RELAX, PSEUDO or CHECK
+        solvecip -- should the CIP of the subproblem be solved, if False, then only the convex relaxation is solved
+        benders -- the Benders' decomposition to which the subproblem belongs to
+        solution -- the master problem solution that is used for the set up, if None, then the LP solution is used
+        """
+
+        cdef SCIP_BENDERS* scip_benders
+        cdef SCIP_Real objective
+        cdef SCIP_Bool infeasible
+
+        if isinstance(sol, Solution):
+            scip_sol = sol.sol
+        else:
+            scip_sol = NULL
+
+        if benders is None:
+            scip_benders = SCIPfindBenders(self._scip, "default")
+        else:
+            n = str_conversion(benders.name)
+            scip_benders = SCIPfindBenders(self._scip, n)
+
+        PY_SCIP_CALL(SCIPsolveBendersSubproblem(self._scip, scip_benders, scip_sol,
+            probnumber, &infeasible, enfotype, solvecip, &objective))
+
+        return infeasible, objective
 
     def getBendersVar(self, Variable var, Benders benders = None, probnumber = -1):
         """Returns the variable for the subproblem or master problem


### PR DESCRIPTION
Wrapper functions for C functions in the SCIP API. The wrapped functions are:

`SCIPsetupBendersSubproblem`: used to fixed the subproblem variables to the values given by the master problem solution
`SCIPsolveBendersSubproblem`: solves a single subproblem as given by the problem index

These wrappers are provided to support the building of custom Benders' decomposition plugins.