### PR TITLE
add functionality to access SCIP_NLROWs

### DIFF
--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -276,6 +276,9 @@ cdef extern from "scip/scip.h":
     ctypedef struct SCIP_ROW:
         pass
 
+    ctypedef struct SCIP_NLROW:
+        pass
+
     ctypedef struct SCIP_COL:
         pass
 
@@ -441,6 +444,11 @@ cdef extern from "scip/scip.h":
     ctypedef struct SCIP_BILINTERM:
         SCIP_VAR* var1
         SCIP_VAR* var2
+        SCIP_Real coef
+
+    ctypedef struct SCIP_QUADELEM:
+        int idx1
+        int idx2
         SCIP_Real coef
 
     ctypedef void (*messagecallback) (SCIP_MESSAGEHDLR *messagehdlr, FILE *file, const char *msg)
@@ -1393,6 +1401,27 @@ cdef extern from "scip/pub_nlp.h":
     SCIP_RETCODE SCIPexprtreeSetVars(SCIP_EXPRTREE* tree,
                                      int nvars,
                                      SCIP_VAR** vars)
+
+
+    SCIP_Real SCIPnlrowGetConstant(SCIP_NLROW* nlrow)
+    int SCIPnlrowGetNLinearVars(SCIP_NLROW* nlrow)
+    SCIP_VAR** SCIPnlrowGetLinearVars(SCIP_NLROW* nlrow)
+    SCIP_Real* SCIPnlrowGetLinearCoefs(SCIP_NLROW* nlrow)
+    void SCIPnlrowGetQuadData(SCIP_NLROW* nlrow,
+                              int* nquadvars,
+                              SCIP_VAR*** quadvars,
+                              int* nquadelems,
+                              SCIP_QUADELEM** quadelems)
+    SCIP_EXPRTREE* SCIPnlrowGetExprtree(SCIP_NLROW* nlrow)
+    SCIP_Real SCIPnlrowGetLhs(SCIP_NLROW* nlrow)
+    SCIP_Real SCIPnlrowGetRhs(SCIP_NLROW* nlrow)
+    const char* SCIPnlrowGetName(SCIP_NLROW* nlrow)
+    SCIP_Real SCIPnlrowGetDualsol(SCIP_NLROW* nlrow)
+
+cdef extern from "scip/scip_nlp.h":
+    SCIP_Bool SCIPisNLPConstructed(SCIP* scip)
+    SCIP_NLROW** SCIPgetNLPNlRows(SCIP* scip)
+    int SCIPgetNNLPNlRows(SCIP* scip)
 
 cdef extern from "scip/cons_nonlinear.h":
     SCIP_RETCODE SCIPcreateConsNonlinear(SCIP* scip,

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -429,15 +429,14 @@ cdef class NLRow:
         return SCIPnlrowGetConstant(self.scip_nlrow)
 
     def getLinearTerms(self):
-        """returns a list of linear terms of a nonlinear row"""
+        """returns a list of tuples (var, coef) representing the linear part of a nonlinear row"""
         cdef SCIP_VAR** linvars = SCIPnlrowGetLinearVars(self.scip_nlrow)
         cdef SCIP_Real* lincoefs = SCIPnlrowGetLinearCoefs(self.scip_nlrow)
         cdef int nlinvars = SCIPnlrowGetNLinearVars(self.scip_nlrow)
         return [(Variable.create(linvars[i]), lincoefs[i]) for i in range(nlinvars)]
 
     def getQuadraticTerms(self):
-        """returns a list of quadratic terms of a nonlinear row"""
-
+        """returns a list of tuples (var1, var2, coef) representing the quadratic part of a nonlinear row"""
         cdef int nquadvars;
         cdef SCIP_VAR** quadvars;
         cdef int nquadelems;
@@ -2367,7 +2366,7 @@ cdef class Model:
         return SCIPgetNNLPNlRows(self._scip)
 
     def getNlRows(self):
-        """returns the nonlinear rows in SCIP's internal NLP"""
+        """returns a list with the nonlinear rows in SCIP's internal NLP"""
         cdef SCIP_NLROW** nlrows;
 
         nlrows = SCIPgetNLPNlRows(self._scip)

--- a/tests/test_nlrow.py
+++ b/tests/test_nlrow.py
@@ -1,0 +1,84 @@
+import pytest
+
+from pyscipopt import Model, quicksum, SCIP_PARAMSETTING
+
+def test_nlrow():
+
+    # create nonlinear model
+    m = Model("nlrow")
+
+    # create variables
+    x = m.addVar(name="x", lb=-3, ub=3, obj=-1)
+    y = m.addVar(name="y", lb=-3, ub=3, obj=-1)
+
+    # create constraints
+    m.addCons(1*x + 2*y + 3 * x**2 + 4*y**2  + 5*x*y <= 6)
+    m.addCons(7*x**2 + 8*y**2 == 9)
+    m.addCons(10*x + 11*y <= 12)
+
+    # optimize without presolving
+    m.setPresolve(SCIP_PARAMSETTING.OFF)
+    m.optimize()
+
+    # check whether NLP has been constructed and there are 3 nonlinear rows that match the above constraints
+    assert m.isNLPConstructed()
+    assert m.getNNlRows() == 3
+
+    # collect nonlinear rows
+    nlrows = m.getNlRows()
+
+    # check first nonlinear row
+    assert nlrows[0].getLhs() == -m.infinity()
+    assert nlrows[0].getRhs() == 6
+
+    linterms = nlrows[0].getLinearTerms()
+    assert len(linterms) == 2
+    assert str(linterms[0][0]) == "t_x"
+    assert linterms[0][1] == 1
+    assert str(linterms[1][0]) == "t_y"
+    assert linterms[1][1] == 2
+
+    quadterms = nlrows[0].getQuadraticTerms()
+    assert len(quadterms) == 3
+    assert str(quadterms[0][0]) == "t_x"
+    assert str(quadterms[0][1]) == "t_x"
+    assert quadterms[0][2] == 3
+    assert str(quadterms[1][0]) == "t_y"
+    assert str(quadterms[1][1]) == "t_y"
+    assert quadterms[1][2] == 4
+    assert str(quadterms[2][0]) == "t_x"
+    assert str(quadterms[2][1]) == "t_y"
+    assert quadterms[2][2] == 5
+
+    # check second nonlinear row
+    assert nlrows[1].getLhs() == 9
+    assert nlrows[1].getRhs() == 9
+
+    linterms = nlrows[1].getLinearTerms()
+    assert len(linterms) == 0
+
+    quadterms = nlrows[1].getQuadraticTerms()
+    assert len(quadterms) == 2
+    assert str(quadterms[0][0]) == "t_x"
+    assert str(quadterms[0][1]) == "t_x"
+    assert quadterms[0][2] == 7
+    assert str(quadterms[1][0]) == "t_y"
+    assert str(quadterms[1][1]) == "t_y"
+    assert quadterms[1][2] == 8
+
+    # check third nonlinear row
+    assert nlrows[2].getLhs() == -m.infinity()
+    assert nlrows[2].getRhs() == 12
+
+    linterms = nlrows[2].getLinearTerms()
+    assert len(linterms) == 2
+    assert str(linterms[0][0]) == "t_x"
+    assert linterms[0][1] == 10
+    assert str(linterms[1][0]) == "t_y"
+    assert linterms[1][1] == 11
+
+    quadterms = nlrows[2].getQuadraticTerms()
+    assert len(quadterms) == 0
+
+if __name__ == "__main__":
+    test_nlrow()


### PR DESCRIPTION
I have added a new class for SCIP_NLROWs. This is useful if one needs to have a global view on the problem. Iterating through the constraints is in general not possible because there might be some upgraded constraints that are not supported by the Python interface.