### PR TITLE
Correct type signature mismatches in SCIPlpiCreate and SCIPgetObjlimit

### DIFF
--- a/src/pyscipopt/lp.pxi
+++ b/src/pyscipopt/lp.pxi
@@ -13,9 +13,9 @@ cdef class LP:
         self.name = name
         n = str_conversion(name)
         if sense == "minimize":
-            PY_SCIP_CALL(SCIPlpiCreate(&(self.lpi), NULL, n, SCIP_OBJSENSE_MINIMIZE))
+            PY_SCIP_CALL(SCIPlpiCreate(&(self.lpi), NULL, n, SCIP_OBJSEN_MINIMIZE))
         elif sense == "maximize":
-            PY_SCIP_CALL(SCIPlpiCreate(&(self.lpi), NULL, n, SCIP_OBJSENSE_MAXIMIZE))
+            PY_SCIP_CALL(SCIPlpiCreate(&(self.lpi), NULL, n, SCIP_OBJSEN_MAXIMIZE))
         else:
             raise Warning("unrecognized objective sense")
 

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -32,6 +32,11 @@ cdef extern from "scip/scip.h":
         SCIP_OBJSENSE_MAXIMIZE = -1
         SCIP_OBJSENSE_MINIMIZE =  1
 
+    # This version is used in LPI.
+    ctypedef enum SCIP_OBJSEN:
+        SCIP_OBJSEN_MAXIMIZE = -1
+        SCIP_OBJSEN_MINIMIZE =  1
+
     ctypedef enum SCIP_BOUNDTYPE:
         SCIP_BOUNDTYPE_LOWER = 0
         SCIP_BOUNDTYPE_UPPER = 1
@@ -575,7 +580,7 @@ cdef extern from "scip/scip.h":
     SCIP_RETCODE SCIPsetObjsense(SCIP* scip, SCIP_OBJSENSE objsense)
     SCIP_OBJSENSE SCIPgetObjsense(SCIP* scip)
     SCIP_RETCODE SCIPsetObjlimit(SCIP* scip, SCIP_Real objlimit)
-    SCIP_RETCODE SCIPgetObjlimit(SCIP* scip)
+    SCIP_Real SCIPgetObjlimit(SCIP* scip)
     SCIP_RETCODE SCIPaddObjoffset(SCIP* scip, SCIP_Real addval)
     SCIP_RETCODE SCIPaddOrigObjoffset(SCIP* scip, SCIP_Real addval)
     SCIP_Real SCIPgetOrigObjoffset(SCIP* scip)
@@ -1135,7 +1140,7 @@ cdef extern from "scip/scip.h":
 
     # LPI Functions
     SCIP_RETCODE SCIPgetLPI(SCIP* scip, SCIP_LPI** lpi)
-    SCIP_RETCODE SCIPlpiCreate(SCIP_LPI** lpi, SCIP_MESSAGEHDLR* messagehdlr, const char* name, SCIP_OBJSENSE objsen)
+    SCIP_RETCODE SCIPlpiCreate(SCIP_LPI** lpi, SCIP_MESSAGEHDLR* messagehdlr, const char* name, SCIP_OBJSEN objsen)
     SCIP_RETCODE SCIPlpiFree(SCIP_LPI** lpi)
     SCIP_RETCODE SCIPlpiWriteLP(SCIP_LPI* lpi, const char* fname)
     SCIP_RETCODE SCIPlpiReadLP(SCIP_LPI* lpi, const char* fname)


### PR DESCRIPTION
The difference between `SCIP_OBJSEN` and `SCIP_OBJSENSE` seems harmless but triggered compiler errors for me. The incorrect return type of `SCIPgetObjLimit` looks like a bug.