### PR TITLE
Adapt setup to other SCIP installations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ if "--debug" in sys.argv:
     extra_compile_args.append('-UNDEBUG')
     sys.argv.remove("--debug")
 
+# avoid errors if SCIP is build with make:
+extra_compile_args.append('-DNO_CONFIG_HEADER')
+
 extensions = [Extension('pyscipopt.scip', [os.path.join(packagedir, 'scip'+ext)],
                           include_dirs=[includedir],
                           library_dirs=[libdir],

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,6 @@ scipoptdir = os.environ.get('SCIPOPTDIR', '').strip('"')
 
 extra_compile_args = []
 extra_link_args = []
-# set runtime libraries
-if platform.system() in ['Linux', 'Darwin']:
-    extra_link_args.append('-Wl,-rpath,'+libdir)
-
-# enable debug mode if requested
-if "--debug" in sys.argv:
-    extra_compile_args.append('-UNDEBUG')
-    sys.argv.remove("--debug")
 
 # determine include directory
 if os.path.exists(os.path.join(scipoptdir, 'src')):
@@ -37,6 +29,15 @@ else:
     libname = 'scip'
 
 print('Using SCIP library <%s> at <%s>.' % (libname,libdir))
+
+# set runtime libraries
+if platform.system() in ['Linux', 'Darwin']:
+    extra_link_args.append('-Wl,-rpath,'+libdir)
+
+# enable debug mode if requested
+if "--debug" in sys.argv:
+    extra_compile_args.append('-UNDEBUG')
+    sys.argv.remove("--debug")
 
 cythonize = True
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, Extension
 import os, platform, sys, re
 
+runtime_library_dirs = []
+extra_link_args = []
+
 # look for environment variable that specifies path to SCIP
 scipoptdir = os.environ.get('SCIPOPTDIR', '').strip('"')
 
@@ -19,12 +22,11 @@ if os.path.exists(os.path.join(scipoptdir, 'lib/shared/libscipsolver.so')):
     # SCIP seems to be created with make
     libdir = os.path.abspath(os.path.join(scipoptdir, 'lib/shared'))
     libname = 'scipsolver'
-    withmake = 1
+    extra_compile_args.append('-DNO_CONFIG_HEADER')
 else:
     # assume that SCIP is installed on the system
     libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
     libname = 'scip'
-    withmake = 0
 
 print('Using SCIP library <%s> at <%s>.' % (libname,libdir))
 
@@ -50,8 +52,6 @@ if not os.path.exists(os.path.join(packagedir, 'scip.pyx')):
 ext = '.pyx' if cythonize else '.c'
 
 # set runtime libraries
-runtime_library_dirs = []
-extra_link_args = []
 if platform.system() in ['Linux', 'Darwin']:
     extra_link_args.append('-Wl,-rpath,'+libdir)
 
@@ -60,10 +60,6 @@ extra_compile_args = []
 if "--debug" in sys.argv:
     extra_compile_args.append('-UNDEBUG')
     sys.argv.remove("--debug")
-
-# avoid errors if SCIP is build with make:
-if withmake == 1:
-    extra_compile_args.append('-DNO_CONFIG_HEADER')
 
 extensions = [Extension('pyscipopt.scip', [os.path.join(packagedir, 'scip'+ext)],
                           include_dirs=[includedir],

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 from setuptools import setup, Extension
 import os, platform, sys, re
 
-runtime_library_dirs = []
-extra_link_args = []
-
 # look for environment variable that specifies path to SCIP
 scipoptdir = os.environ.get('SCIPOPTDIR', '').strip('"')
+
+extra_compile_args = []
+extra_link_args = []
+# set runtime libraries
+if platform.system() in ['Linux', 'Darwin']:
+    extra_link_args.append('-Wl,-rpath,'+libdir)
+
+# enable debug mode if requested
+if "--debug" in sys.argv:
+    extra_compile_args.append('-UNDEBUG')
+    sys.argv.remove("--debug")
 
 # determine include directory
 if os.path.exists(os.path.join(scipoptdir, 'src')):
@@ -51,21 +59,10 @@ if not os.path.exists(os.path.join(packagedir, 'scip.pyx')):
 
 ext = '.pyx' if cythonize else '.c'
 
-# set runtime libraries
-if platform.system() in ['Linux', 'Darwin']:
-    extra_link_args.append('-Wl,-rpath,'+libdir)
-
-# enable debug mode if requested
-extra_compile_args = []
-if "--debug" in sys.argv:
-    extra_compile_args.append('-UNDEBUG')
-    sys.argv.remove("--debug")
-
 extensions = [Extension('pyscipopt.scip', [os.path.join(packagedir, 'scip'+ext)],
                           include_dirs=[includedir],
                           library_dirs=[libdir],
                           libraries=[libname],
-                          runtime_library_dirs=runtime_library_dirs,
                           extra_compile_args = extra_compile_args,
                           extra_link_args=extra_link_args
                           )]

--- a/setup.py
+++ b/setup.py
@@ -4,28 +4,29 @@ import os, platform, sys, re
 # look for environment variable that specifies path to SCIP
 scipoptdir = os.environ.get('SCIPOPTDIR', '').strip('"')
 
-# now check whether SCIP is installed on the system or whether a source code directory has been specified
-if os.path.exists(os.path.join(scipoptdir, 'include')):
-    includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
+# determine include directory
+if os.path.exists(os.path.join(scipoptdir, 'src')):
+    # SCIP seems to be installed in place
+    includedir = os.path.abspath(os.path.join(scipoptdir, 'src'))
 else:
-    if os.path.exists(os.path.join(scipoptdir, 'src')):
-        includedir = os.path.abspath(os.path.join(scipoptdir, 'src'))
-    else:
-        print('Neither directory \'src\' nor \'include\' exists in the path <%s>' % scipoptdir)
-        quit(1)
+    # assume that SCIP is installed on the system
+    includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
+
+print('Using include path <%s>.' % includedir)
 
 # determine library
-libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
-libname = 'scip'
-if (not os.path.exists(os.path.join(libdir, 'libscip.so'))) and (not os.path.exists('/usr/lib/libscip.so')):
-    if os.path.exists(os.path.join(libdir, 'shared/libscipsolver.so')):
-        print('SCIP library <%s> does not exist.\nUsing <%s> instead.' % (os.path.join(libdir, 'libscip.so'), os.path.join(libdir, 'shared/libscipsolver.so')))
-        libdir = os.path.abspath(os.path.join(scipoptdir, 'lib/shared'))
-        libname = 'scipsolver'
-    else:
-        print('SCIP library does not exist - tried <lib/libscip.so> and <lib/shared/libscipsolver.so>.')
-        quit(1)
+if os.path.exists(os.path.join(scipoptdir, 'lib/shared/libscipsolver.so')):
+    # SCIP seems to be created with make
+    libdir = os.path.abspath(os.path.join(scipoptdir, 'lib/shared'))
+    libname = 'scipsolver'
+    withmake = 1
+else:
+    # assume that SCIP is installed on the system
+    libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
+    libname = 'scip'
+    withmake = 0
 
+print('Using SCIP library <%s> at <%s>.' % (libname,libdir))
 
 cythonize = True
 
@@ -61,7 +62,8 @@ if "--debug" in sys.argv:
     sys.argv.remove("--debug")
 
 # avoid errors if SCIP is build with make:
-extra_compile_args.append('-DNO_CONFIG_HEADER')
+if withmake == 1:
+    extra_compile_args.append('-DNO_CONFIG_HEADER')
 
 extensions = [Extension('pyscipopt.scip', [os.path.join(packagedir, 'scip'+ext)],
                           include_dirs=[includedir],

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,31 @@
 from setuptools import setup, Extension
 import os, platform, sys, re
 
-# look for environment variable that specifies path to SCIP Opt lib and headers
+# look for environment variable that specifies path to SCIP
 scipoptdir = os.environ.get('SCIPOPTDIR', '').strip('"')
-includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
+
+# now check whether SCIP is installed on the system or whether a source code directory has been specified
+if os.path.exists(os.path.join(scipoptdir, 'include')):
+    includedir = os.path.abspath(os.path.join(scipoptdir, 'include'))
+else:
+    if os.path.exists(os.path.join(scipoptdir, 'src')):
+        includedir = os.path.abspath(os.path.join(scipoptdir, 'src'))
+    else:
+        print('Neither directory \'src\' nor \'include\' exists in the path <%s>' % scipoptdir)
+        quit(1)
+
+# determine library
 libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
 libname = 'scip'
+if not os.path.exists(os.path.join(libdir, 'libscip.so')):
+    if os.path.exists(os.path.join(libdir, 'shared/libscipsolver.so')):
+        print('SCIP library <%s> does not exist.\nUsing <%s> instead.' % (os.path.join(libdir, 'libscip.so'), os.path.join(libdir, 'shared/libscipsolver.so')))
+        libdir = os.path.abspath(os.path.join(scipoptdir, 'lib/shared'))
+        libname = 'scipsolver'
+    else:
+        print('SCIP library does not exist - tried <lib/libscip.so> and <lib/shared/libscipsolver.so>.')
+        quit(1)
+
 
 cythonize = True
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ else:
 # determine library
 libdir = os.path.abspath(os.path.join(scipoptdir, 'lib'))
 libname = 'scip'
-if not os.path.exists(os.path.join(libdir, 'libscip.so')):
+if (not os.path.exists(os.path.join(libdir, 'libscip.so'))) and (not os.path.exists('/usr/lib/libscip.so')):
     if os.path.exists(os.path.join(libdir, 'shared/libscipsolver.so')):
         print('SCIP library <%s> does not exist.\nUsing <%s> instead.' % (os.path.join(libdir, 'libscip.so'), os.path.join(libdir, 'shared/libscipsolver.so')))
         libdir = os.path.abspath(os.path.join(scipoptdir, 'lib/shared'))


### PR DESCRIPTION
This PR should make it possible to also use SCIP that is not installed at a central place.
The code should now work both with SCIP directories that are built using cmake as well as make.