### PR TITLE
Check whether PY_SCIP_CALL is defined in __dealloc__. 

### DIFF
--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -781,7 +781,7 @@ cdef class Model:
     def __dealloc__(self):
         # call C function directly, because we can no longer call this object's methods, according to
         # http://docs.cython.org/src/reference/extension_types.html#finalization-dealloc
-        if self._scip is not NULL and self._freescip:
+        if self._scip is not NULL and self._freescip and PY_SCIP_CALL:
            PY_SCIP_CALL( SCIPfree(&self._scip) )
 
     @staticmethod


### PR DESCRIPTION
PY_SCIP_CALL may have already been garbage collected by the time this method is called, causing an exception.