### PR TITLE
Add scip.Model export to / import from Python pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - remove Python 2 support
 - add Model.getParams that returns a dict mapping all parameter names to their values
 - add Model.setParams to set multiple parameters at once using a dict
+- Add Model.from_ptr and Model.to_ptr to interface with SCIP* managed outside of PySCIPOpt
 
 ## 2.2.3 - 2019-12-10
 ### Added

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -767,21 +767,21 @@ cdef class Model:
         return model
 
     @property
-    def _freescip(self) -> bool:
+    def _freescip(self):
         """Return whether the underlying Scip pointer gets deallocted when the current
         object is deleted.
         """
         return self._freescip
 
     @_freescip.setter
-    def _freescip(self, val: bool) -> None:
+    def _freescip(self, val):
         """Set whether the underlying Scip pointer gets deallocted when the current
         object is deleted.
         """
         self._freescip = val
 
     @staticmethod
-    def from_ptr(scip_ptr: ctypes.c_void_p, take_ownership: bool) -> Model:
+    def from_ptr(scip_ptr, take_ownership):
         """Create a Model from a given pointer.
 
         :param scip_ptr: The pointer used to create the Model.
@@ -792,7 +792,7 @@ cdef class Model:
         model._freescip = take_ownership
         return model
 
-    def to_ptr(self, give_ownership: bool) -> ctypes.c_void_p:
+    def to_ptr(self, give_ownership):
         """Return the underlying Scip pointer to the current Model.
 
         :param give_ownership: Whether the current Model gives away ownership of the

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -5,7 +5,6 @@ from os.path import abspath
 from os.path import splitext
 import sys
 import warnings
-import ctypes
 
 cimport cython
 from cpython cimport Py_INCREF, Py_DECREF
@@ -781,15 +780,16 @@ cdef class Model:
         """
         self._freescip = val
 
+    @cython.always_allow_keywords(True)
     @staticmethod
-    def from_ptr(scip_ptr, take_ownership):
+    def from_ptr(uintptr_t scip_ptr, take_ownership):
         """Create a Model from a given pointer.
 
         :param scip_ptr: The pointer used to create the Model.
         :param take_ownership: Whether the newly created Model assumes ownership of the
         underlying Scip pointer (see `_freescip`).
         """
-        model = Model.create(<SCIP*><uintptr_t>(scip_ptr.value))
+        model = Model.create(<SCIP*>scip_ptr)
         model._freescip = take_ownership
         return model
 
@@ -801,7 +801,7 @@ cdef class Model:
         underlying Scip pointer (see `_freescip`).
         :return scip_ptr: The underlying pointer to the current Model.
         """
-        ptr = ctypes.c_void_p(<uintptr_t>self._scip)
+        ptr = <uintptr_t>self._scip
         if give_ownership:
             self._freescip = False
         return ptr

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -7,6 +7,7 @@ import sys
 import warnings
 import ctypes
 
+cimport cython
 from cpython cimport Py_INCREF, Py_DECREF
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport fdopen
@@ -792,6 +793,7 @@ cdef class Model:
         model._freescip = take_ownership
         return model
 
+    @cython.always_allow_keywords(True)
     def to_ptr(self, give_ownership):
         """Return the underlying Scip pointer to the current Model.
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -76,5 +76,17 @@ def test_model():
 
     assert s.getStatus() == 'unbounded'
 
+
+def test_model_ptr():
+    model1 = Model()
+    ptr1 = model1.to_ptr(give_ownership=True)
+    assert not model1._freescip
+
+    model2 = Model.from_ptr(ptr1, take_ownership=True)
+    assert model2._freescip
+    assert model2.to_ptr(False) == ptr1
+
+
 if __name__ == "__main__":
     test_model()
+    test_model_ptr()


### PR DESCRIPTION
Here's a working solution to resolve #330 
Turns out `uintptr_t` was the key to proper casting, while `ctypes.c_void_p` is just a wrapper around an `int`.

- [x] Add export/import functions
- [x] Document functions
- [x] Add test