### PR TITLE
fixes for Benders tests

### DIFF
--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3075,15 +3075,15 @@ cdef class Model:
         """
         SCIPbendersSetSubproblemIsConvex(benders._benders, probnumber, isconvex)
 
-    def setupBendersSubproblem(self, probnumber, checktype, Benders benders = None, Solution solution = None):
+    def setupBendersSubproblem(self, probnumber, Benders benders = None, Solution solution = None, checktype = PY_SCIP_BENDERSENFOTYPE.LP):
         """ sets up the Benders' subproblem given the master problem solution
 
         Keyword arguments:
         probnumber -- the index of the problem that is to be set up
-        checktype -- the type of solution check that prompted the solving of the Benders' subproblems, either
-            PY_SCIP_BENDERSENFOTYPE: LP, RELAX, PSEUDO or CHECK
         benders -- the Benders' decomposition to which the subproblem belongs to
         solution -- the master problem solution that is used for the set up, if None, then the LP solution is used
+        checktype -- the type of solution check that prompted the solving of the Benders' subproblems, either
+            PY_SCIP_BENDERSENFOTYPE: LP, RELAX, PSEUDO or CHECK. Default is LP
         """
         cdef SCIP_BENDERS* scip_benders
         cdef SCIP_SOL* scip_sol

--- a/tests/test_customizedbenders.py
+++ b/tests/test_customizedbenders.py
@@ -196,7 +196,8 @@ def test_flpbenders_defcuts():
     master = flp(I, J, M, d, f)
     # initializing the default Benders' decomposition with the subproblem
     master.setPresolve(SCIP_PARAMSETTING.OFF)
-    master.setBoolParam("misc/allowdualreds", False)
+    master.setBoolParam("misc/allowstrongdualreds", False)
+    master.setBoolParam("misc/allowweakdualreds", False)
     master.setBoolParam("benders/copybenders", False)
     bendersName = "testBenders"
     testbd = testBenders(master.data, I, J, M, c, d, bendersName)
@@ -242,7 +243,8 @@ def test_flpbenders_customcuts():
     master = flp(I, J, M, d, f)
     # initializing the default Benders' decomposition with the subproblem
     master.setPresolve(SCIP_PARAMSETTING.OFF)
-    master.setBoolParam("misc/allowdualreds", False)
+    master.setBoolParam("misc/allowstrongdualreds", False)
+    master.setBoolParam("misc/allowweakdualreds", False)
     master.setBoolParam("benders/copybenders", False)
     bendersName = "testBenders"
     benderscutName = "testBenderscut"


### PR DESCRIPTION
The Benders test used `allowdualreds` parameter. This has been changed to `allowstrongdualreds` and `allowweakdualreds`.

Also, it was discovered that the enforcement type in the `setupBendersSubproblem` is not needed in general. As such, a default of `PY_SCIP_BENDERSENFOTYPE.LP` is set for `checktype`.