### PR TITLE
Add branch priority

### DIFF
--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1652,6 +1652,9 @@ cdef extern from "scip/pub_lp.h":
 cdef extern from "scip/scip_tree.h":
     SCIP_RETCODE SCIPgetOpenNodesData(SCIP* scip, SCIP_NODE*** leaves, SCIP_NODE*** children, SCIP_NODE*** siblings, int* nleaves, int* nchildren, int* nsiblings)
 
+cdef extern from "scip/scip_var.h":
+    SCIP_RETCODE SCIPchgVarBranchPriority(SCIP* scip, SCIP_VAR* var, int branchpriority)
+
 cdef class Expr:
     cdef public terms
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -4537,6 +4537,15 @@ cdef class Model:
 
         free(_coeffs)
 
+    def chgVarBranchPriority(self, Variable var, priority):
+        """Set the branch priority of a variable.
+
+        :param Variable var: variable to change priority of
+        :param priority: the new priority of the variable (each variable is initialized with 0 as priority)
+        """
+        assert isinstance(var, Variable), "The given variable is not a pyvar, but %s" % var.__class__.__name__
+        PY_SCIP_CALL(SCIPchgVarBranchPriority(self._scip, var.scip_var, priority))
+
 # debugging memory management
 def is_memory_freed():
     return BMSgetMemoryUsed() == 0

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -4538,10 +4538,11 @@ cdef class Model:
         free(_coeffs)
 
     def chgVarBranchPriority(self, Variable var, priority):
-        """Set the branch priority of a variable.
+        """Sets the branch priority of the variable.
+        Variables with higher branch priority are always preferred to variables with lower priority in selection of branching variable.
 
         :param Variable var: variable to change priority of
-        :param priority: the new priority of the variable (each variable is initialized with 0 as priority)
+        :param priority: the new priority of the variable (the default branching priority is 0)
         """
         assert isinstance(var, Variable), "The given variable is not a pyvar, but %s" % var.__class__.__name__
         PY_SCIP_CALL(SCIPchgVarBranchPriority(self._scip, var.scip_var, priority))


### PR DESCRIPTION
This pull request adds a pure wrapper of the SCIP function "SCIPchgVarBranchPriority" from "scip/scip_var.h".
The python version can be accessed from `Model`.chgVarBranchPriority(`Variable` var, priority).

No tests/examples are provided, since it is a direct wrapper of a SCIP method.