### PR TITLE
update getDualMultiplier and getDualsolLinear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - `Model.from_ptr` and `Model.to_ptr` use a `PyCapsule` to exchange the SCIP pointer
   rather than an integer.
+- mark getDualMultiplier() as deprecated, only getDualMultiplier() is supposed to be used to get duals of constraints
 
 ## 3.0.0 - 2020-04-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 - `Model.from_ptr` and `Model.to_ptr` use a `PyCapsule` to exchange the SCIP pointer
   rather than an integer.
-- mark getDualMultiplier() as deprecated, only getDualMultiplier() is supposed to be used to get duals of constraints
+- mark getDualMultiplier() as deprecated, only getDualSolLinear() is supposed to be used to get duals of constraints
 
 ## 3.0.0 - 2020-04-11
 ### Added

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -2872,8 +2872,8 @@ cdef class Model:
             valsdict[bytes(SCIPvarGetName(_vars[i])).decode('utf-8')] = _vals[i]
         return valsdict
 
-    def getDualMultiplier(self, Constraint cons):
-        """Retrieve the dual multiplier to a linear constraint.
+    def getDualsolLinear(self, Constraint cons):
+        """Retrieve the dual solution to a linear constraint.
 
         :param Constraint cons: linear constraint
 
@@ -2887,51 +2887,15 @@ cdef class Model:
             transcons = cons
         return SCIPgetDualsolLinear(self._scip, transcons.scip_cons)
 
-    def getDualsolLinear(self, Constraint cons):
-        """Retrieve the dual solution to a linear constraint.
+    def getDualMultiplier(self, Constraint cons):
+        """DEPRECATED: Retrieve the dual solution to a linear constraint.
 
         :param Constraint cons: linear constraint
 
         """
-        cdef SCIP_Real dualsolval
-        cdef SCIP_Bool boundconstraint
-        cdef int _nvars
-        cdef SCIP_VAR** _vars
-        cdef SCIP_Real* _vals
-        cdef SCIP_Bool _success
-
-        if self.version() > 6.0:
-            PY_SCIP_CALL( SCIPgetDualSolVal(self._scip, cons.scip_cons, &dualsolval, &boundconstraint) )
-            return dualsolval
-        else:
-            dual = 0.0
-
-            constype = bytes(SCIPconshdlrGetName(SCIPconsGetHdlr(cons.scip_cons))).decode('UTF-8')
-            if not constype == 'linear':
-                raise Warning("dual solution values not available for constraints of type ", constype)
-
-            try:
-                _nvars = SCIPgetNVarsLinear(self._scip, cons.scip_cons)
-                if cons.isOriginal():
-                    transcons = <Constraint>self.getTransformedCons(cons)
-                else:
-                    transcons = cons
-                dual = SCIPgetDualsolLinear(self._scip, transcons.scip_cons)
-                if dual == 0.0 and _nvars == 1:
-                    _vars = SCIPgetVarsLinear(self._scip, transcons.scip_cons)
-                    _vals = SCIPgetValsLinear(self._scip, transcons.scip_cons)
-                    activity = SCIPvarGetLPSol(_vars[0]) * _vals[0]
-                    rhs = SCIPgetRhsLinear(self._scip, transcons.scip_cons)
-                    lhs = SCIPgetLhsLinear(self._scip, transcons.scip_cons)
-                    if (activity == rhs) or (activity == lhs):
-                        dual = SCIPgetVarRedcost(self._scip, _vars[0])
-
-                if self.getObjectiveSense() == "maximize" and not dual == 0.0:
-                    dual = -dual
-            except:
-                raise Warning("no dual solution available for constraint " + cons.name)
-            return dual
-
+        raise Warning("model.getDualMultiplier(cons) is deprecated: please use model.getDualsolLinear(cons)")
+        return self.getDualsolLinear(cons)
+        
     def getDualfarkasLinear(self, Constraint cons):
         """Retrieve the dual farkas value to a linear constraint.
 

--- a/tests/test_customizedbenders.py
+++ b/tests/test_customizedbenders.py
@@ -106,20 +106,20 @@ class testBenderscut(Benderscut):
       for i in self.I:
          subprobcons = self.benders.demand[i]
          try:
-            dualmult = subprob.getDualSolLinear(subprobcons)
+            dualmult = subprob.getDualsolLinear(subprobcons)
             lhs += dualmult*self.d[i]
          except:
             print("Subproblem constraint <%d> does not exist in the "\
                   "subproblem."%subprobcons.name)
             assert False
 
-         memberdualmult = membersubprob.getDualSolLinear(subprobcons)
+         memberdualmult = membersubprob.getDualsolLinear(subprobcons)
          if dualmult != memberdualmult:
             print("The dual multipliers between the two subproblems are not "\
                   "the same.")
             assert False
 
-      coeffs = [subprob.getDualSolLinear(self.benders.capacity[j])*\
+      coeffs = [subprob.getDualsolLinear(self.benders.capacity[j])*\
             self.M[j] for j in self.J]
 
       self.model.addCons(self.model.getBendersAuxiliaryVar(probnumber,

--- a/tests/test_customizedbenders.py
+++ b/tests/test_customizedbenders.py
@@ -106,20 +106,20 @@ class testBenderscut(Benderscut):
       for i in self.I:
          subprobcons = self.benders.demand[i]
          try:
-            dualmult = subprob.getDualMultiplier(subprobcons)
+            dualmult = subprob.getDualSolLinear(subprobcons)
             lhs += dualmult*self.d[i]
          except:
             print("Subproblem constraint <%d> does not exist in the "\
                   "subproblem."%subprobcons.name)
             assert False
 
-         memberdualmult = membersubprob.getDualMultiplier(subprobcons)
+         memberdualmult = membersubprob.getDualSolLinear(subprobcons)
          if dualmult != memberdualmult:
             print("The dual multipliers between the two subproblems are not "\
                   "the same.")
             assert False
 
-      coeffs = [subprob.getDualMultiplier(self.benders.capacity[j])*\
+      coeffs = [subprob.getDualSolLinear(self.benders.capacity[j])*\
             self.M[j] for j in self.J]
 
       self.model.addCons(self.model.getBendersAuxiliaryVar(probnumber,

--- a/tests/test_pricer.py
+++ b/tests/test_pricer.py
@@ -8,7 +8,7 @@ class CutPricer(Pricer):
         # Retrieving the dual solutions
         dualSolutions = []
         for i, c in enumerate(self.data['cons']):
-            dualSolutions.append(self.model.getDualMultiplier(c))
+            dualSolutions.append(self.model.getDualSolLinear(c))
 
         # Building a MIP to solve the subproblem
         subMIP = Model("CuttingStock-Sub")

--- a/tests/test_pricer.py
+++ b/tests/test_pricer.py
@@ -8,7 +8,7 @@ class CutPricer(Pricer):
         # Retrieving the dual solutions
         dualSolutions = []
         for i, c in enumerate(self.data['cons']):
-            dualSolutions.append(self.model.getDualSolLinear(c))
+            dualSolutions.append(self.model.getDualsolLinear(c))
 
         # Building a MIP to solve the subproblem
         subMIP = Model("CuttingStock-Sub")


### PR DESCRIPTION
according to #385 

This marks getDualMultiplier as deprecated and getDualsolLinear actually behaves as intended (wrapping the corresponding SCIP function).