### PR TITLE
remove python 3.5 from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ environment:
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: C:\Python35-x64
-      PIP: C:\Python35-x64\Scripts\pip
-      PYTEST: C:\Python35-x64\Scripts\pytest
-      TWINE: C:\Python35-x64\Scripts\twine
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PYTHON: C:\Python36-x64
       PIP: C:\Python36-x64\Scripts\pip
       PYTEST: C:\Python36-x64\Scripts\pytest


### PR DESCRIPTION
Apparently, there is some issue with building the py-3.5 package for Windows and since this a rather old version, I guess it's fine to just remove it.