### PR TITLE
fix getTransformedVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - strip quotes from SCIPOPTDIR path variable that might confuse Windows systems
+* `getTransformedVar` now uses `SCIPgetTransformedVar` instead of `SCIPtransformVar` which captures the variable
 
 ## 3.0.2 - 2020-08-09
 ### Added

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -704,6 +704,7 @@ cdef extern from "scip/scip.h":
     SCIP_RETCODE SCIPaddPricedVar(SCIP* scip, SCIP_VAR* var, SCIP_Real score)
     SCIP_RETCODE SCIPreleaseVar(SCIP* scip, SCIP_VAR** var)
     SCIP_RETCODE SCIPtransformVar(SCIP* scip, SCIP_VAR* var, SCIP_VAR** transvar)
+    SCIP_RETCODE SCIPgetTransformedVar(SCIP* scip, SCIP_VAR* var, SCIP_VAR** transvar)
     SCIP_RETCODE SCIPaddVarLocks(SCIP* scip, SCIP_VAR* var, int nlocksdown, int nlocksup)
     SCIP_VAR** SCIPgetVars(SCIP* scip)
     SCIP_VAR** SCIPgetOrigVars(SCIP* scip)

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -1453,7 +1453,8 @@ cdef class Model:
 
         """
         cdef SCIP_VAR* _tvar
-        PY_SCIP_CALL(SCIPtransformVar(self._scip, var.scip_var, &_tvar))
+        PY_SCIP_CALL(SCIPgetTransformedVar(self._scip, var.scip_var, &_tvar))
+
         return Variable.create(_tvar)
 
     def addVarLocks(self, Variable var, nlocksdown, nlocksup):


### PR DESCRIPTION
`getTransformedVar` was using `SCIPtransformVar` which on top of transforming the variable, it captures it. Thus, the variables were unreleased at the end.
Fixes #439 